### PR TITLE
Update dependencies and hide Now page

### DIFF
--- a/AboutMe/Wasm/AboutMe.Wasm.csproj
+++ b/AboutMe/Wasm/AboutMe.Wasm.csproj
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.6" PrivateAssets="all" />
-        <PackageReference Include="MudBlazor" Version="8.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
+        <PackageReference Include="MudBlazor" Version="8.10.0" />
     </ItemGroup>
 
 </Project>

--- a/AboutMe/Wasm/Layout/NavMenu.razor
+++ b/AboutMe/Wasm/Layout/NavMenu.razor
@@ -4,10 +4,12 @@
         Home
     </MudNavLink>
 
+@*
     <MudNavLink Href="now"
                 Match="@NavLinkMatch.All">
         Now
     </MudNavLink>
+*@
 
     <MudNavLink Href="resume"
                 Match="@NavLinkMatch.All">

--- a/AboutMe/Wasm/Pages/Now.razor
+++ b/AboutMe/Wasm/Pages/Now.razor
@@ -1,4 +1,4 @@
-﻿@page "/now"
+﻿@* @page "/now" *@
 
 <PageTitle>
     @Constants.SiteName - Now

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "9.0.301"
+    "version": "9.0.303"
   }
 }


### PR DESCRIPTION
Upgraded Microsoft.AspNetCore.Components.WebAssembly and MudBlazor package versions. Updated .NET SDK version in global.json. Commented out the Now page route and removed its navigation link from the menu.