### PR TITLE
Update SDK and NuGet packages; bump MudBlazor to 9.0.0

### DIFF
--- a/AboutMe/Wasm/AboutMe.Wasm.csproj
+++ b/AboutMe/Wasm/AboutMe.Wasm.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Humanizer" Version="3.0.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" PrivateAssets="all"/>
-        <PackageReference Include="MudBlazor" Version="8.15.0"/>
+        <PackageReference Include="Humanizer" Version="3.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
+        <PackageReference Include="MudBlazor" Version="9.0.0" />
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.102"
+    "version": "10.0.103"
   }
 }


### PR DESCRIPTION
Updated .NET SDK in global.json to 10.0.103. Upgraded Microsoft.AspNetCore.Components.WebAssembly and DevServer packages to 10.0.3, and MudBlazor to 9.0.0 in AboutMe.Wasm.csproj. Also applied minor formatting improvements to PackageReference elements.