### PR TITLE
Bump Wasm packages and .NET SDK

### DIFF
--- a/AboutMe/Wasm/AboutMe.Wasm.csproj
+++ b/AboutMe/Wasm/AboutMe.Wasm.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Humanizer" Version="3.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
-        <PackageReference Include="MudBlazor" Version="9.0.0" />
+        <PackageReference Include="Humanizer" Version="3.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.4"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.4" PrivateAssets="all"/>
+        <PackageReference Include="MudBlazor" Version="9.1.0"/>
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.103"
+    "version": "10.0.104"
   }
 }


### PR DESCRIPTION
Upgrade dependencies in AboutMe.Wasm: Humanizer 3.0.1 → 3.0.10, Microsoft.AspNetCore.Components.WebAssembly 10.0.3 → 10.0.4 (and DevServer), and MudBlazor 9.0.0 → 9.1.0. Also bump global .NET SDK version from 10.0.103 to 10.0.104 to align with the updates. These are minor/patch upgrades to pick up bug fixes and improvements.