### PR TITLE
Bump SDK, NuGet packages, and GitHub Actions

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -28,7 +28,7 @@ jobs:
 
       # sets up .NET SDK
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
           global-json-file: ./global.json
 

--- a/.github/workflows/main_aboutcodemonkey85.yml
+++ b/.github/workflows/main_aboutcodemonkey85.yml
@@ -25,7 +25,7 @@ jobs:
 
       # sets up .NET SDK
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
           global-json-file: ./global.json
 

--- a/AboutMe/Wasm/AboutMe.Wasm.csproj
+++ b/AboutMe/Wasm/AboutMe.Wasm.csproj
@@ -13,9 +13,9 @@
 
     <ItemGroup>
         <PackageReference Include="Humanizer" Version="3.0.10"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.4"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.4" PrivateAssets="all"/>
-        <PackageReference Include="MudBlazor" Version="9.1.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all"/>
+        <PackageReference Include="MudBlazor" Version="9.2.0"/>
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.104"
+    "version": "10.0.201"
   }
 }


### PR DESCRIPTION
## Summary

Consolidates all open dependabot PRs (#124, #131, #132, #133, #134) into a single update:

- **dotnet-sdk**: 10.0.104 → 10.0.201
- **Microsoft.AspNetCore.Components.WebAssembly**: 10.0.4 → 10.0.5
- **Microsoft.AspNetCore.Components.WebAssembly.DevServer**: 10.0.4 → 10.0.5
- **MudBlazor**: 9.1.0 → 9.2.0
- **actions/setup-dotnet**: v5.1.0 → v5.2.0

## Test plan

- [ ] CI build passes on this PR
- [ ] Wasm app builds and runs correctly after SDK bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)