### PR TITLE
Normalize line endings and bump SDK/packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####
@@ -362,7 +362,7 @@ dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 dotnet_style_readonly_field = true:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
-* text=auto
+* text=auto eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/AboutMe/Wasm/AboutMe.Wasm.csproj
+++ b/AboutMe/Wasm/AboutMe.Wasm.csproj
@@ -13,9 +13,9 @@
 
     <ItemGroup>
         <PackageReference Include="Humanizer" Version="3.0.10"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all"/>
-        <PackageReference Include="MudBlazor" Version="9.2.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" PrivateAssets="all"/>
+        <PackageReference Include="MudBlazor" Version="9.3.0"/>
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.201"
+    "version": "10.0.202"
   }
 }


### PR DESCRIPTION
Enforce LF line endings by changing end_of_line to lf in .editorconfig and adding eol=lf in .gitattributes. Update global.json to use .NET SDK 10.0.202 and bump AboutMe.Wasm package references: Microsoft.AspNetCore.Components.WebAssembly and its DevServer to 10.0.6, and MudBlazor to 9.3.0. These changes standardize repository line endings and update dependencies to newer patch/minor releases.