### PR TITLE
Bump WASM packages and SDK versions

### DIFF
--- a/AboutMe/Wasm/AboutMe.Wasm.csproj
+++ b/AboutMe/Wasm/AboutMe.Wasm.csproj
@@ -13,9 +13,9 @@
 
     <ItemGroup>
         <PackageReference Include="Humanizer" Version="3.0.10"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" PrivateAssets="all"/>
-        <PackageReference Include="MudBlazor" Version="9.3.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all"/>
+        <PackageReference Include="MudBlazor" Version="9.4.0"/>
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.202"
+    "version": "10.0.203"
   }
 }


### PR DESCRIPTION
Upgrade AboutMe.Wasm package references: Microsoft.AspNetCore.Components.WebAssembly and its DevServer from 10.0.6 to 10.0.7, and MudBlazor from 9.3.0 to 9.4.0. Also bump the .NET SDK version in global.json from 10.0.202 to 10.0.203 to align with the updated packages and toolchain.